### PR TITLE
fix(typo): fix typo on update effect during mutation

### DIFF
--- a/docs/renderer/mutation.md
+++ b/docs/renderer/mutation.md
@@ -209,9 +209,9 @@ fiberP.sibling.child
 
 ## Update effect
 
-当`Fiber节点`含有`Update effectTag`，意味着该`Fiber节点`需要更新。调用的方法为`commitPlacement`，他会根据`Fiber.tag`分别处理。
+当`Fiber节点`含有`Update effectTag`，意味着该`Fiber节点`需要更新。调用的方法为`commitWork`，他会根据`Fiber.tag`分别处理。
 
-> 你可以在[这里](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberCommitWork.new.js#L1451)看到`commitPlacement`源码
+> 你可以在[这里](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberCommitWork.new.js#L1451)看到`commitWork`源码
 
 这里我们主要关注`FunctionComponent`和`HostComponent`。
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50568923/86136981-4db04780-bb1f-11ea-9703-c0cf4d2cab80.png)

文中[链接](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberCommitWork.new.js#L1451)指向Commit Work.
[源码](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberWorkLoop.new.js#L2191
)中也有指出Update是在commitPlacement之后调用的commitWork.

烦请作者看看是不是我理解有误，还是说这里是个typo。