### PR TITLE
fix: Hooks章节中极简Hooks实现代码错误

### DIFF
--- a/docs/hooks/create.md
+++ b/docs/hooks/create.md
@@ -343,7 +343,7 @@ function useState(initialState) {
       const action = firstUpdate.action;
       baseState = action(baseState);
       firstUpdate = firstUpdate.next;
-    } while (firstUpdate !== hook.queue.pending)
+    } while (firstUpdate !== hook.queue.pending.next)
 
     hook.queue.pending = null;
   }


### PR DESCRIPTION
在该章节的计算state小节里，完整代码示例中，useState函数退出循环的判断条件有误。