### PR TITLE
Line36-mistake

### DIFF
--- a/docs/hooks/usememo.md
+++ b/docs/hooks/usememo.md
@@ -33,7 +33,7 @@ function mountCallback<T>(callback: T, deps: Array<mixed> | void | null): T {
 
 - `mountMemo`会将`回调函数`(nextCreate)的执行结果作为`value`保存
 
-- `mountCallback`会保存`回调函数`果作为`value`保存
+- `mountCallback`会将`回调函数`作为`value`保存
 
 ## update
 


### PR DESCRIPTION
当前状态为：- `mountCallback`会保存`回调函数`果作为`value`保存。

错误描述：行文词不达意，略有模糊。作者本人原意为：“会将`回调函数`作为`value`保存”，但却多了“果”字。

建议更改为：- `mountCallback`会将`回调函数`作为`value`保存。